### PR TITLE
Fix NTS starting issue

### DIFF
--- a/internal/nts/entrypoint.sh
+++ b/internal/nts/entrypoint.sh
@@ -35,14 +35,13 @@ sigterm_handler() {
 trap 'sigterm_handler' SIGTERM
 
 umask 002
+export NES_SERVER_CONF=/var/lib/appliance/nts/nts.cfg
 exec /root/nes-daemon \
     -n 4 \
     --lcores='(0,3,4,5)@0,1@3,2@4' \
     --huge-dir /hugepages \
     --file-prefix=vhost-1 \
-    --socket-mem ${NTS_SOCKET0_MEM},${NTS_SOCKET1_MEM} \
-    -- \
-    /var/lib/appliance/nts/nts.cfg &
+    --socket-mem ${NTS_SOCKET0_MEM},${NTS_SOCKET1_MEM} &
 nts_pid="$!"
 
 exec /root/kni_docker_daemon.py \

--- a/internal/nts/tests/run-tests.sh
+++ b/internal/nts/tests/run-tests.sh
@@ -71,7 +71,8 @@ mkdir -p /mnt/huge
 mount -t hugetlbfs none /mnt/huge
 rm -rf daemon/build
 make clean && make
-./daemon/build/nes-daemon-unit-tests -c 0xe -n 4  --huge-dir /mnt/huge --file-prefix=tests-1 --socket-mem 2048,0 -- ${CMDLINE_CONF_PATH}
+export NES_SERVER_CONF=${CMDLINE_CONF_PATH}
+./daemon/build/nes-daemon-unit-tests -c 0xe -n 4  --huge-dir /mnt/huge --file-prefix=tests-1 --socket-mem 2048,0
 
 rm -rf /mnt/huge/*
 umount /mnt/huge/


### PR DESCRIPTION
Signed-off-by: root <root@localhost.localdomain>
We found NTS starting issue while configuring interfaces. The right way to pass config file is exporting an environment variable e.g. export NES_SERVER_CONF=/var/lib/appliance/nts/nts.cfg