### PR TITLE
Avoid using explicit version for sudo

### DIFF
--- a/build/edgednssvr/Dockerfile
+++ b/build/edgednssvr/Dockerfile
@@ -4,7 +4,7 @@
 FROM alpine:3.12.0 AS edgedns-deps-image
 
 RUN printf "http://nl.alpinelinux.org/alpine/v3.12/main\nhttp://nl.alpinelinux.org/alpine/v3.12/community" >> /etc/apk/repositories
-RUN apk add --no-cache sudo=1.9.0-r0
+RUN apk add --no-cache sudo
 
 FROM edgedns-deps-image
 


### PR DESCRIPTION
Using an explicit version of sudo does not looks like
the requirement, thus removing the version based package
add to fix the break for image build

Signed-off-by: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>