### PR TITLE
filter services/endpoints for given node

### DIFF
--- a/edgecontroller/network-edge/kube-ovn/kubectl-interfaceservice
+++ b/edgecontroller/network-edge/kube-ovn/kubectl-interfaceservice
@@ -64,7 +64,7 @@ fail_if_var_empty() {
 get_node_service() {
     node=${1:-}
     svc=${2:-}
-    endpoints=$(kubectl get endpoints -o custom-columns=NAME:.metadata.name,NODE:.subsets[*].addresses[*].ip,IP:.subsets[*].addresses[*].nodeName -n openness --no-headers | grep "^${svc}")
+    endpoints=$(kubectl get endpoints -o custom-columns=NAME:.metadata.name,NODE:.subsets[*].addresses[*].ip,IP:.subsets[*].addresses[*].nodeName -n openness --no-headers | grep "^${svc}" | grep "${node}")
 
     if [[ ! "${endpoints}" ]] ; then
         error "Service '${svc}' not found on node '${node}'"


### PR DESCRIPTION
Issue #29 - get_node_service does not filter services for given node.
Function does not exit with "Service '${svc}' not found on node '${node}'"
if service is found on other node(s).
Filtering for given node was added.